### PR TITLE
Refactor parallel MCTS memory and evaluation pipeline: dynamic shared arrays, board replay, vectorized selection, and batched eval flow

### DIFF
--- a/search.py
+++ b/search.py
@@ -6,13 +6,12 @@ from model import ChessAttention, HISTORY_LEN, HISTORY_PAD_IDX
 import moves
 import tqdm
 import multiprocessing as mp
-from multiprocessing import Queue, Process, Value, Array, Manager
+from multiprocessing import Queue, Process, Value, Array
 import ctypes
 import time
-import os
+from queue import Empty, Full
 
 # ---------------- Config ----------------
-MAX_NODES = 500_000
 CONTEXT_LENGTH = 2688
 MAX_PIECES = 33
 C_PUCT = 2.0
@@ -22,60 +21,62 @@ NUM_WORKERS = 4  # Start with fewer workers
 BATCH_SIZE = 16  # Smaller batch size to start
 DIRICHLET_ALPHA = 0.3
 NOISE_EPS = 0.25
+MAX_CHILDREN_EST = 64
 
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 # ---------------- Shared Arrays using multiprocessing.Array ----------------
-def create_shared_arrays():
+def create_shared_arrays(max_nodes):
     """Create shared arrays using multiprocessing.Array (more reliable than shared_memory)"""
     arrays = {
-        'N': Array(ctypes.c_int32, MAX_NODES, lock=False),
-        'W': Array(ctypes.c_float, MAX_NODES, lock=False),
-        'Wanti': Array(ctypes.c_float, MAX_NODES, lock=False),
-        'Q': Array(ctypes.c_float, MAX_NODES, lock=False),
-        'antiQ': Array(ctypes.c_float, MAX_NODES, lock=False),
-        'VAR': Array(ctypes.c_float, MAX_NODES, lock=False),
-        'PRIOR': Array(ctypes.c_float, MAX_NODES, lock=False),
-        'TURN': Array(ctypes.c_bool, MAX_NODES, lock=False),
-        'VLOSS': Array(ctypes.c_int16, MAX_NODES, lock=False),
-        'EXP': Array(ctypes.c_bool, MAX_NODES, lock=False),
-        'PARENT': Array(ctypes.c_int32, MAX_NODES, lock=False),
-        'CH_PTR': Array(ctypes.c_int32, MAX_NODES, lock=False),
-        'CH_LEN': Array(ctypes.c_int16, MAX_NODES, lock=False),
-        'CH_BUF': Array(ctypes.c_int32, MAX_NODES * 8, lock=False),
-        'QW_BUF': Array(ctypes.c_float, MAX_NODES * 8, lock=False),
-        'NODE_LOCKS': Array(ctypes.c_uint8, MAX_NODES, lock=False),
+        'N': Array(ctypes.c_int32, max_nodes, lock=False),
+        'W': Array(ctypes.c_float, max_nodes, lock=False),
+        'Wanti': Array(ctypes.c_float, max_nodes, lock=False),
+        'Q': Array(ctypes.c_float, max_nodes, lock=False),
+        'antiQ': Array(ctypes.c_float, max_nodes, lock=False),
+        'VAR': Array(ctypes.c_float, max_nodes, lock=False),
+        'PRIOR': Array(ctypes.c_float, max_nodes, lock=False),
+        'TURN': Array(ctypes.c_bool, max_nodes, lock=False),
+        'VLOSS': Array(ctypes.c_int16, max_nodes, lock=False),
+        'EXP': Array(ctypes.c_bool, max_nodes, lock=False),
+        'PARENT': Array(ctypes.c_int32, max_nodes, lock=False),
+        'CH_PTR': Array(ctypes.c_int32, max_nodes, lock=False),
+        'CH_LEN': Array(ctypes.c_int16, max_nodes, lock=False),
+        'CH_BUF': Array(ctypes.c_int32, max_nodes * MAX_CHILDREN_EST, lock=False),
+        'QW_BUF': Array(ctypes.c_float, max_nodes * MAX_CHILDREN_EST, lock=False),
+        'NODE_LOCKS': Array(ctypes.c_uint8, max_nodes, lock=False),
+        'MOVE_BUF': Array(ctypes.c_int32, max_nodes, lock=False),
     }
     
     # Initialize
-    for i in range(MAX_NODES):
+    for i in range(max_nodes):
         arrays['VAR'][i] = 1.0
         arrays['PARENT'][i] = -1
+        arrays['MOVE_BUF'][i] = -1
     
-    for i in range(MAX_NODES * 8):
+    for i in range(max_nodes * MAX_CHILDREN_EST):
         arrays['CH_BUF'][i] = -1
     
     return arrays
 
-def create_shared_tensors():
+def create_shared_tensors(max_nodes):
     """Create large tensor arrays separately"""
-    # Use RawArray for large tensors (no locking overhead)
-    ctx_array = mp.RawArray(ctypes.c_float, MAX_NODES * CONTEXT_LENGTH)
-    board_array = mp.RawArray(ctypes.c_float, MAX_NODES * MAX_PIECES * 4)
-    return ctx_array, board_array
+    return mp.RawArray(ctypes.c_uint16, max_nodes * CONTEXT_LENGTH)
 
 # ---------------- Worker Globals ----------------
 N = W = Wanti = Q = antiQ = VAR = PRIOR = TURN = VLOSS = EXP = None
 PARENT = CH_PTR = CH_LEN = CH_BUF = QW_BUF = NODE_LOCKS = None
-CTX_RAW = BOARD_RAW = None
-board_manager = None
-CTX_VIEW = BOARD_VIEW = None
+MOVE_BUF = None
+CTX_RAW = None
+CTX_VIEW = None
+ROOT_FEN = None
+MAX_NODES = 0
 
-def init_worker_arrays(shared_arrays, ctx_raw, board_raw, board_mgr):
+def init_worker_arrays(shared_arrays, ctx_raw, root_fen, max_nodes):
     """Initialize arrays in worker process"""
     global N, W, Wanti, Q, antiQ, VAR, PRIOR, TURN, VLOSS, EXP
-    global PARENT, CH_PTR, CH_LEN, CH_BUF, QW_BUF, NODE_LOCKS
-    global CTX_RAW, BOARD_RAW, board_manager, CTX_VIEW, BOARD_VIEW
+    global PARENT, CH_PTR, CH_LEN, CH_BUF, QW_BUF, NODE_LOCKS, MOVE_BUF
+    global CTX_RAW, CTX_VIEW, ROOT_FEN, MAX_NODES
     
     N = shared_arrays['N']
     W = shared_arrays['W']
@@ -93,11 +94,11 @@ def init_worker_arrays(shared_arrays, ctx_raw, board_raw, board_mgr):
     CH_BUF = shared_arrays['CH_BUF']
     QW_BUF = shared_arrays['QW_BUF']
     NODE_LOCKS = shared_arrays['NODE_LOCKS']
+    MOVE_BUF = shared_arrays['MOVE_BUF']
     CTX_RAW = ctx_raw
-    BOARD_RAW = board_raw
-    board_manager = board_mgr
-    CTX_VIEW = np.frombuffer(CTX_RAW, dtype=np.float32).reshape(MAX_NODES, CONTEXT_LENGTH)
-    BOARD_VIEW = np.frombuffer(BOARD_RAW, dtype=np.float32).reshape(MAX_NODES, MAX_PIECES, 4)
+    ROOT_FEN = root_fen
+    MAX_NODES = max_nodes
+    CTX_VIEW = np.frombuffer(CTX_RAW, dtype=np.float16).reshape(MAX_NODES, CONTEXT_LENGTH)
 
 # ---------------- Helper Functions ----------------
 def get_ctx(nid):
@@ -106,15 +107,21 @@ def get_ctx(nid):
 
 def set_ctx(nid, ctx):
     """Set context for a node"""
-    CTX_VIEW[nid] = ctx
+    CTX_VIEW[nid] = np.asarray(ctx, dtype=np.float16)
 
-def get_board(nid):
-    """Get board tensor for a node"""
-    return BOARD_VIEW[nid]
-
-def set_board(nid, board_tensor):
-    """Set board tensor for a node"""
-    BOARD_VIEW[nid] = board_tensor
+def reconstruct_board(nid):
+    board = chess.Board(ROOT_FEN)
+    seq = []
+    cur = nid
+    while cur > 0:
+        mv_idx = MOVE_BUF[cur]
+        if mv_idx < 0:
+            break
+        seq.append(mv_idx)
+        cur = PARENT[cur]
+    for mv_idx in reversed(seq):
+        board.push(chess.Move.from_uci(moves.pmoves[mv_idx]))
+    return board
 
 def board_to_tensor(board):
     tens = np.zeros((MAX_PIECES, 4), dtype=np.float32)
@@ -141,12 +148,17 @@ def board_to_history(board):
 def alloc_node(node_counter, node_lock):
     with node_lock:
         nid = node_counter.value
+        if nid >= MAX_NODES:
+            return -1
         node_counter.value += 1
         return nid
 
 def alloc_children(k, child_counter, child_lock):
     with child_lock:
         ptr = child_counter.value
+        max_children = MAX_NODES * MAX_CHILDREN_EST
+        if ptr + k > max_children:
+            return -1
         child_counter.value += k
         return ptr
 
@@ -195,28 +207,24 @@ def select_path(root):
         k = CH_LEN[nid]
         
         # Safely get children
-        kids = [CH_BUF[ptr + i] for i in range(k)]
-        
-        # Calculate scores and choose best in one pass
-        sqrt_parent = math.sqrt(N[nid] + 1)
-        best_score = -float("inf")
-        best_idx = 0
-        for i, kid in enumerate(kids):
-            n = N[kid] + VLOSS[kid]
-            w = W[kid] - VIRTUAL_LOSS * VLOSS[kid]
-            q = w / max(n, 1)
-            aq = Wanti[kid] / max(n, 1)
-            
-            weight = QW_BUF[ptr + i]
-            value = q if TURN[kid] == TURN[nid] else aq
-            exploit = weight * value
-            
-            u = C_PUCT * PRIOR[kid] * sqrt_parent / (1 + n) * VAR[kid]
+        kids = np.frombuffer(CH_BUF, dtype=np.int32, count=k, offset=ptr * np.dtype(np.int32).itemsize).copy()
 
-            score = exploit + u
-            if score > best_score:
-                best_score = score
-                best_idx = i
+        sqrt_parent = math.sqrt(N[nid] + 1)
+        n_vals = np.fromiter((N[k] + VLOSS[k] for k in kids), dtype=np.float32, count=k)
+        w_vals = np.fromiter((W[k] - VIRTUAL_LOSS * VLOSS[k] for k in kids), dtype=np.float32, count=k)
+        wanti_vals = np.fromiter((Wanti[k] for k in kids), dtype=np.float32, count=k)
+        turn_vals = np.fromiter((TURN[k] for k in kids), dtype=np.bool_, count=k)
+        prior_vals = np.fromiter((PRIOR[k] for k in kids), dtype=np.float32, count=k)
+        var_vals = np.fromiter((VAR[k] for k in kids), dtype=np.float32, count=k)
+        qw_vals = np.frombuffer(QW_BUF, dtype=np.float32, count=k, offset=ptr * np.dtype(np.float32).itemsize)
+
+        denom = np.maximum(n_vals, 1.0)
+        q_vals = w_vals / denom
+        aq_vals = wanti_vals / denom
+        value = np.where(turn_vals == TURN[nid], q_vals, aq_vals)
+        exploit = qw_vals * value
+        explore = C_PUCT * prior_vals * sqrt_parent / (1.0 + n_vals) * var_vals
+        best_idx = int(np.argmax(exploit + explore))
 
         # Select best child
         idx = best_idx
@@ -226,7 +234,7 @@ def select_path(root):
     
     return nid, path
 
-def expand(nid, policy, new_ctx, var, node_counter, node_lock, child_counter, child_lock):
+def expand(nid, policy, var, node_counter, node_lock, child_counter, child_lock):
     if not acquire_node(nid):
         return
     
@@ -234,29 +242,29 @@ def expand(nid, policy, new_ctx, var, node_counter, node_lock, child_counter, ch
         if EXP[nid]:
             return
         
-        board = board_manager[nid]
+        board = reconstruct_board(nid)
         legal = list(board.legal_moves)
         if not legal:
             EXP[nid] = True
             return
         
         ptr = alloc_children(len(legal), child_counter, child_lock)
+        if ptr < 0:
+            return
         CH_PTR[nid] = ptr
         CH_LEN[nid] = len(legal)
         
         for i, mv in enumerate(legal):
             cid = alloc_node(node_counter, node_lock)
+            if cid < 0:
+                CH_LEN[nid] = i
+                break
             CH_BUF[ptr + i] = cid
-            
-            nb = board.copy(stack=False)
-            nb.push(mv)
-            board_manager[cid] = nb
-            set_board(cid, board_to_tensor(nb))
-            set_ctx(cid, new_ctx)
             
             PARENT[cid] = nid
             TURN[cid] = not board.turn
             PRIOR[cid] = policy.get(mv.uci(), 0.0)
+            MOVE_BUF[cid] = moves.pmove_to_idx.get(mv.uci(), -1)
         
         update_weights(nid)
         EXP[nid] = True
@@ -315,11 +323,11 @@ def backup(path, leaf, v, av, var):
         update_weights(pid)
 
 # ---------------- Search Worker ----------------
-def search_worker(worker_id, shared_arrays, ctx_raw, board_raw, board_mgr,
+def search_worker(worker_id, shared_arrays, ctx_raw, root_fen, max_nodes,
                   node_counter, node_lock, child_counter, child_lock,
-                  eval_queue, result_queue, stop_flag, root_node, eps=NOISE_EPS, alpha=DIRICHLET_ALPHA, use_anti=True):
+                  eval_queue, result_queue, stop_flag, root_node, sims_target, eps=NOISE_EPS, alpha=DIRICHLET_ALPHA, use_anti=True):
     try:
-        init_worker_arrays(shared_arrays, ctx_raw, board_raw, board_mgr)
+        init_worker_arrays(shared_arrays, ctx_raw, root_fen, max_nodes)
         print(f"Worker {worker_id} started")
         rng = np.random.default_rng(worker_id + int(time.time()))
         timings = {
@@ -330,39 +338,63 @@ def search_worker(worker_id, shared_arrays, ctx_raw, board_raw, board_mgr,
             "backup": 0.0,
         }
         iterations = 0
+        req_id = 0
+        in_flight = {}
+        max_in_flight = 2
         
         while not stop_flag.value:
             try:
-                t0 = time.perf_counter()
-                leaf, path = select_path(root_node)
-                timings["select"] += time.perf_counter() - t0
-                
-                if EXP[leaf]:
-                    for nid in path:
-                        VLOSS[nid] = max(0, VLOSS[nid] - 1)
-                    continue
-                
-                t0 = time.perf_counter()
-                eval_queue.put((worker_id, leaf, path))
-                timings["enqueue"] += time.perf_counter() - t0
+                loop_progress = False
+                while True:
+                    t0 = time.perf_counter()
+                    try:
+                        result = result_queue.get_nowait()
+                    except Empty:
+                        timings["wait_result"] += time.perf_counter() - t0
+                        break
+                    timings["wait_result"] += time.perf_counter() - t0
+                    loop_progress = True
+                    if result is None:
+                        stop_flag.value = 1
+                        break
+                    done_req_id, nid, policy, v, av, var, new_ctx = result
+                    path = in_flight.pop(done_req_id, None)
+                    if path is None:
+                        continue
+                    policy = add_dirichlet_noise(policy, rng, eps=eps, alpha=alpha)
+                    set_ctx(nid, new_ctx)
+                    t0 = time.perf_counter()
+                    expand(nid, policy, var, node_counter, node_lock, child_counter, child_lock)
+                    timings["expand"] += time.perf_counter() - t0
+                    t0 = time.perf_counter()
+                    backup(path, nid, v, av, var)
+                    timings["backup"] += time.perf_counter() - t0
+                    iterations += 1
 
-                t0 = time.perf_counter()
-                result = result_queue.get(timeout=10)
-                timings["wait_result"] += time.perf_counter() - t0
-                
-                if result is None:
-                    break
-                
-                nid, policy, v, av, var, new_ctx = result
-                policy = add_dirichlet_noise(policy, rng, eps=eps, alpha=alpha)
-                set_ctx(nid, new_ctx)
-                t0 = time.perf_counter()
-                expand(nid, policy, new_ctx, var, node_counter, node_lock, child_counter, child_lock)
-                timings["expand"] += time.perf_counter() - t0
-                t0 = time.perf_counter()
-                backup(path, nid, v, av, var)
-                timings["backup"] += time.perf_counter() - t0
-                iterations += 1
+                while len(in_flight) < max_in_flight and not stop_flag.value:
+                    if N[root_node] + len(in_flight) >= sims_target:
+                        break
+                    t0 = time.perf_counter()
+                    leaf, path = select_path(root_node)
+                    timings["select"] += time.perf_counter() - t0
+                    if EXP[leaf]:
+                        for pid in path:
+                            VLOSS[pid] = max(0, VLOSS[pid] - 1)
+                        continue
+                    t0 = time.perf_counter()
+                    try:
+                        eval_queue.put_nowait((worker_id, req_id, leaf))
+                        in_flight[req_id] = path
+                        req_id += 1
+                        loop_progress = True
+                    except Full:
+                        for pid in path:
+                            VLOSS[pid] = max(0, VLOSS[pid] - 1)
+                        break
+                    timings["enqueue"] += time.perf_counter() - t0
+
+                if not loop_progress:
+                    time.sleep(0.001)
                 
             except Exception as e:
                 print(f"Worker {worker_id} iteration error: {e}")
@@ -376,10 +408,10 @@ def search_worker(worker_id, shared_arrays, ctx_raw, board_raw, board_mgr,
         traceback.print_exc()
 
 # ---------------- Evaluation Worker ----------------
-def evaluation_worker(shared_arrays, ctx_raw, board_raw, board_mgr,
+def evaluation_worker(shared_arrays, ctx_raw, root_fen, max_nodes,
                       eval_queue, result_queues, stop_flag, batch_size=BATCH_SIZE):
     try:
-        init_worker_arrays(shared_arrays, ctx_raw, board_raw, board_mgr)
+        init_worker_arrays(shared_arrays, ctx_raw, root_fen, max_nodes)
         
         print("Loading model...")
         model = ChessAttention().to(device).eval()
@@ -415,12 +447,14 @@ def evaluation_worker(shared_arrays, ctx_raw, board_raw, board_mgr,
                     pending_evals = pending_evals[batch_size:]
                     
                     worker_ids = [item[0] for item in batch]
-                    leaf_nodes = [item[1] for item in batch]
+                    req_ids = [item[1] for item in batch]
+                    leaf_nodes = [item[2] for item in batch]
                     
                     # Get tensors
                     t0 = time.perf_counter()
-                    boards_list = [get_board(nid) for nid in leaf_nodes]
-                    history_list = [board_to_history(board_mgr[nid]) for nid in leaf_nodes]
+                    boards_for_nodes = [reconstruct_board(nid) for nid in leaf_nodes]
+                    boards_list = [board_to_tensor(board) for board in boards_for_nodes]
+                    history_list = [board_to_history(board) for board in boards_for_nodes]
                     
                     boards_np = np.stack(boards_list, axis=0)
                     history_np = np.stack(history_list, axis=0)
@@ -443,7 +477,7 @@ def evaluation_worker(shared_arrays, ctx_raw, board_raw, board_mgr,
                     t0 = time.perf_counter()
                     results = []
                     for i, nid in enumerate(leaf_nodes):
-                        board = board_mgr[nid]
+                        board = boards_for_nodes[i]
                         legal = list(board.legal_moves)
                         policy = {}
                         
@@ -472,8 +506,8 @@ def evaluation_worker(shared_arrays, ctx_raw, board_raw, board_mgr,
                     
                     # Send results
                     t0 = time.perf_counter()
-                    for (worker_id, _, _), result in zip(batch, results):
-                        result_queues[worker_id].put(result)
+                    for worker_id, req_id, result in zip(worker_ids, req_ids, results):
+                        result_queues[worker_id].put((req_id, *result))
                     timings["send"] += time.perf_counter() - t0
                     batches += 1
                         
@@ -495,12 +529,9 @@ def evaluation_worker(shared_arrays, ctx_raw, board_raw, board_mgr,
 # ---------------- Main MCTS ----------------
 def run_mcts_parallel(board, sims=800, num_workers=NUM_WORKERS, eps=NOISE_EPS, alpha=DIRICHLET_ALPHA, use_anti=True):
     print("Initializing shared memory...")
-    shared_arrays = create_shared_arrays()
-    ctx_raw, board_raw = create_shared_tensors()
-    
-    print("Initializing board manager...")
-    manager = Manager()
-    board_mgr = manager.dict()
+    max_nodes = max(4096, sims * MAX_CHILDREN_EST + num_workers * 32 + 1)
+    shared_arrays = create_shared_arrays(max_nodes)
+    ctx_raw = create_shared_tensors(max_nodes)
     
     node_counter = Value('i', 1)
     node_lock = mp.Lock()
@@ -509,13 +540,11 @@ def run_mcts_parallel(board, sims=800, num_workers=NUM_WORKERS, eps=NOISE_EPS, a
     
     # Initialize root
     root = 0
-    board_mgr[root] = board
+    root_fen = board.fen()
     
     # Access raw arrays through numpy
-    board_arr = np.frombuffer(board_raw, dtype=np.float32).reshape(MAX_NODES, MAX_PIECES, 4)
-    ctx_arr = np.frombuffer(ctx_raw, dtype=np.float32).reshape(MAX_NODES, CONTEXT_LENGTH)
+    ctx_arr = np.frombuffer(ctx_raw, dtype=np.float16).reshape(max_nodes, CONTEXT_LENGTH)
     
-    board_arr[root] = board_to_tensor(board)
     ctx_arr[root] = 0
     shared_arrays['TURN'][root] = board.turn
     shared_arrays['PRIOR'][root] = 1.0
@@ -527,7 +556,7 @@ def run_mcts_parallel(board, sims=800, num_workers=NUM_WORKERS, eps=NOISE_EPS, a
     print("Starting evaluation worker...")
     eval_proc = Process(
         target=evaluation_worker,
-        args=(shared_arrays, ctx_raw, board_raw, board_mgr, eval_queue, result_queues, stop_flag)
+        args=(shared_arrays, ctx_raw, root_fen, max_nodes, eval_queue, result_queues, stop_flag)
     )
     eval_proc.start()
     
@@ -538,16 +567,16 @@ def run_mcts_parallel(board, sims=800, num_workers=NUM_WORKERS, eps=NOISE_EPS, a
     for i in range(num_workers):
         p = Process(
             target=search_worker,
-            args=(i, shared_arrays, ctx_raw, board_raw, board_mgr,
+            args=(i, shared_arrays, ctx_raw, root_fen, max_nodes,
                   node_counter, node_lock, child_counter, child_lock,
-                  eval_queue, result_queues[i], stop_flag, root, eps, alpha, use_anti)
+                  eval_queue, result_queues[i], stop_flag, root, sims, eps, alpha, use_anti)
         )
         p.start()
         workers.append(p)
     
     print(f"Running {sims} simulations...")
     pbar = tqdm.tqdm(total=sims, desc="Simulations", position=0)
-    node_bar = tqdm.tqdm(total=MAX_NODES, desc="Nodes created", position=1, leave=False)
+    node_bar = tqdm.tqdm(total=max_nodes, desc="Nodes created", position=1, leave=False)
     last_count = 0
     last_nodes = node_counter.value
     
@@ -598,15 +627,14 @@ def run_mcts_parallel(board, sims=800, num_workers=NUM_WORKERS, eps=NOISE_EPS, a
     print(f"\nTotal visits: {shared_arrays['N'][root]}")
     print(f"Nodes created: {node_counter.value}")
     
-    return best, visits, kids, board_mgr
+    best_move_idx = shared_arrays['MOVE_BUF'][best]
+    return best, visits, kids, best_move_idx
 
 # ---------------- Example Usage ----------------
 if __name__ == "__main__":
     mp.set_start_method('spawn')
     
     board = chess.Board()
-    best, visits, kids, board_mgr = run_mcts_parallel(board, sims=200, num_workers=3)
-    
-    best_board = board_mgr[best]
-    print("Best Move:", best_board.peek())
+    best, visits, kids, best_move_idx = run_mcts_parallel(board, sims=200, num_workers=3)
+    print("Best Move:", moves.pmoves[best_move_idx])
     print("Visits:", visits[:10])


### PR DESCRIPTION
### Motivation
- Reduce reliance on a Manager and per-node board copies to lower memory and IPC overhead and enable larger concurrent search trees. 
- Make shared storage sizes configurable at runtime and avoid hard-coded `MAX_NODES` to support variable simulation counts. 
- Speed up selection and worker/evaluator interactions with vectorized operations and in-flight batching to improve throughput.

### Description
- Introduce dynamic sizing by adding `max_nodes` and computing it in `run_mcts_parallel`, and propagate it to `create_shared_arrays` and `create_shared_tensors` instead of using a global `MAX_NODES` constant. 
- Replace per-node `board` Manager dictionary with a replayable move buffer: add `MOVE_BUF` and `ROOT_FEN`, and implement `reconstruct_board(nid)` that rebuilds board state by replaying moves from the root. 
- Change context storage to `float16` using a raw array and views via `CTX_VIEW`, and ensure `set_ctx` casts to `float16`. 
- Remove `board_raw`/board manager usage and associated functions `get_board`/`set_board`; replace them with `reconstruct_board`, `board_to_tensor`, and `board_to_history`. 
- Add bounds checks to `alloc_node` and `alloc_children` to prevent over-allocation and use `MAX_CHILDREN_EST` for child buffer sizing. 
- Vectorize child selection in `select_path` using NumPy to compute `exploit` and `explore` arrays and pick the best child via `argmax`, replacing the previous Python loop. 
- Rework expand logic to no longer copy/store full board objects, store `MOVE_BUF[cid]`, set `PARENT`, `TURN`, and `PRIOR`, and rely on `reconstruct_board` for evaluations. 
- Rework evaluation and search worker protocols to include request IDs and in-flight tracking, allowing multiple outstanding evals per worker and non-blocking queue operations; pass `(worker_id, req_id, leaf)` into the eval queue and expect `(req_id, nid, policy, v, av, var, new_ctx)` back. 
- Update `evaluation_worker` to batch requests, reconstruct boards for each leaf, run the model, and send results back with request IDs, and to signal termination by sending `None`. 
- Miscellaneous: import `Empty` and `Full` from `queue`, add `MAX_CHILDREN_EST` constant, and adjust progress bars and return values to include the chosen move index via `MOVE_BUF`.

### Testing
- Ran a basic smoke/integration run by executing the module `__main__` with `run_mcts_parallel(board, sims=200, num_workers=3)` which started the eval and search workers, completed simulations, and returned a best move and visit counts; the run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5f3c8d6288324966d4ecb4e06688d)